### PR TITLE
fix bug on postgres in tinyint field

### DIFF
--- a/migrations/m140608_173539_create_user_table.php
+++ b/migrations/m140608_173539_create_user_table.php
@@ -20,7 +20,7 @@ class m140608_173539_create_user_table extends Migration
 			'password_hash'      => 'string not null',
 			'confirmation_token' => 'string',
 			'status'             => 'int not null default 1',
-			'superadmin'         => 'tinyint(1) default 0',
+			'superadmin'         => 'smallint default 0',
 			'created_at'         => 'int not null',
 			'updated_at'         => 'int not null',
 		), $tableOptions);

--- a/migrations/m141201_220516_add_email_and_email_confirmed_to_user.php
+++ b/migrations/m141201_220516_add_email_and_email_confirmed_to_user.php
@@ -7,7 +7,7 @@ class m141201_220516_add_email_and_email_confirmed_to_user extends Migration
 	public function safeUp()
 	{
 		$this->addColumn(Yii::$app->getModule('user-management')->user_table, 'email', 'varchar(128)');
-		$this->addColumn(Yii::$app->getModule('user-management')->user_table, 'email_confirmed', 'tinyint(1) not null default 0');
+		$this->addColumn(Yii::$app->getModule('user-management')->user_table, 'email_confirmed', 'smallint(1) not null default 0');
 		Yii::$app->cache->flush();
 
 	}

--- a/migrations/mysql.schema.sql
+++ b/migrations/mysql.schema.sql
@@ -275,13 +275,13 @@ CREATE TABLE IF NOT EXISTS `user` (
   `password_hash` varchar(255) NOT NULL,
   `confirmation_token` varchar(255) DEFAULT NULL,
   `status` int(11) NOT NULL DEFAULT '1',
-  `superadmin` tinyint(1) DEFAULT '0',
+  `superadmin` smallint(1) DEFAULT '0',
   `created_at` int(11) NOT NULL,
   `updated_at` int(11) NOT NULL,
   `registration_ip` varchar(15) DEFAULT NULL,
   `bind_to_ip` varchar(255) DEFAULT NULL,
   `email` varchar(128) DEFAULT NULL,
-  `email_confirmed` tinyint(1) NOT NULL DEFAULT '0',
+  `email_confirmed` smallint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=2 ;
 


### PR DESCRIPTION
the tinyint field caused an error when running the migration in postgres, with this change the migration will be compatible with Postgres and MySQL