### PR TITLE
Fix warning on assigning permission to role

### DIFF
--- a/models/rbacDB/AbstractItem.php
+++ b/models/rbacDB/AbstractItem.php
@@ -256,13 +256,13 @@ abstract class AbstractItem extends ActiveRecord
 		AuthHelper::invalidatePermissions();
 	}
 
-	public function beforeAddChildren($parentName, $childrenNames, $throwException = false)
+	public static function beforeAddChildren($parentName, $childrenNames, $throwException = false)
 	{
 		$event = new AbstractItemEvent(compact('parentName', 'childrenNames', 'throwException'));
 		$event->trigger(get_called_class(), self::EVENT_BEFORE_ADD_CHILDREN, $event);
 	}
 
-	public function beforeRemoveChildren($parentName, $childrenNames)
+	public static function beforeRemoveChildren($parentName, $childrenNames)
 	{
 		$event = new AbstractItemEvent(compact('parentName', 'childrenNames', 'throwException'));
 		$event->trigger(get_called_class(), self::EVENT_BEFORE_REMOVE_CHILDREN, $event);


### PR DESCRIPTION
Non-static method webvimark\modules\UserManagement\models\rbacDB\AbstractItem::beforeAddChildren() should not be called statically