### PR TITLE
NULL value inside UserVisitLog.php causes error

### DIFF
--- a/models/UserVisitLog.php
+++ b/models/UserVisitLog.php
@@ -39,7 +39,7 @@ class UserVisitLog extends \webvimark\components\BaseActiveRecord
 		$model->user_id    = $userId;
 		$model->token      = uniqid();
 		$model->ip         = LittleBigHelper::getRealIp();
-		$model->language   = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2) : null;
+		$model->language   = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2) : '';
 		$model->browser    = $browser->getBrowser();
 		$model->os         = $browser->getPlatform();
 		$model->user_agent = $browser->getUserAgent();


### PR DESCRIPTION
Hey, I have the following problem while doing acceptance tests: The login is not working because the codecept browser language is not set. This will cause an integrity constraint violation because the UserVisitLog.php is setting the language value to NULL but the database does not accept NULL values.

So you should change the UserVisitLog.php as suggested or the user_visit_log should accept NULL values by default migration.

PS: I know you can change the HTTP_ACCEPT_LANGUAGE from the PhpBrowser (I have done it) but this is a potential error source for users. Just wanted to let you know. :)