### PR TITLE
Enable creation of frontend user on backend admin

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -34,6 +34,7 @@ class User extends UserIdentity
 	const STATUS_ACTIVE = 1;
 	const STATUS_INACTIVE = 0;
 	const STATUS_BANNED = -1;
+	const STATUS_FRONTEND = 10;
 
 	/**
 	 * @var string
@@ -207,6 +208,7 @@ class User extends UserIdentity
 			self::STATUS_ACTIVE   => UserManagementModule::t('back', 'Active'),
 			self::STATUS_INACTIVE => UserManagementModule::t('back', 'Inactive'),
 			self::STATUS_BANNED   => UserManagementModule::t('back', 'Banned'),
+			self::STATUS_FRONTEND   => UserManagementModule::t('back', 'Frontend'),
 		);
 	}
 

--- a/views/user/index.php
+++ b/views/user/index.php
@@ -131,6 +131,7 @@ $this->params['breadcrumbs'][] = $this->title;
 						'class'=>'webvimark\components\StatusColumn',
 						'attribute'=>'status',
 						'optionsArray'=>[
+							[User::STATUS_FRONTEND, UserManagementModule::t('back', 'Frontend'), 'success'],
 							[User::STATUS_ACTIVE, UserManagementModule::t('back', 'Active'), 'success'],
 							[User::STATUS_INACTIVE, UserManagementModule::t('back', 'Inactive'), 'warning'],
 							[User::STATUS_BANNED, UserManagementModule::t('back', 'Banned'), 'danger'],


### PR DESCRIPTION
A frontend user has a status of 10. On backend, I can create a user and assign that status, so he will be able to login on frontend as well. How about that?