### PR TITLE
Correction for login redirection under IE.

### DIFF
--- a/components/GhostAccessControl.php
+++ b/components/GhostAccessControl.php
@@ -100,7 +100,7 @@ class GhostAccessControl extends ActionFilter
 	{
 		if ( Yii::$app->user->getIsGuest() )
 		{
-			Yii::$app->user->loginRequired();
+			Yii::$app->user->loginRequired(Yii::$app->request->isAjax, (strpos(Yii::$app->request->headers->get('Accept'), 'html') !== false));
 		}
 		else
 		{
@@ -108,4 +108,4 @@ class GhostAccessControl extends ActionFilter
 		}
 	}
 
-} 
+}


### PR DESCRIPTION
The function loginRequired of yii\web\User accept two parameters since Yii v2.0.8.
See [http://www.yiiframework.com/doc-2.0/yii-web-user.html#loginRequired()-detail](url)

Currently the redirect to the login page is incorrect when text/html is not acceptable (ie, mentioned explicitly, via * or by omission of the Accept header). So instead of redirect user to login page, loginRequired() throws a ForbiddenHttpException...

So, to correct it i check if it's an Ajax request for the first parameter (facultative). Then check if html is accept by headers. If not (case of IE) , loginRequired() won't check it before to redirect to login page. Else, loginRequired() will check it and will redirect to login page as well cause HTML is present in every other browsers.

n.b: you can check loginRequired() function here : [https://github.com/yiisoft/yii2/blob/master/framework/web/User.php#LC418](url)