### PR TITLE
Username label change from Login to Username

### DIFF
--- a/messages/pt-PT/front.php
+++ b/messages/pt-PT/front.php
@@ -21,6 +21,7 @@ return [
     'Check your e-mail {email} for instructions to activate account' => 'Verifique o seu e-mail {email} para obter instruções para ativar a conta',
     'Could not send confirmation email' => 'Não foi possível enviar email de confirmação',
     'Login' => 'Entrar',
+    'Username' => 'Nome de Utilizador',
     'Registration - confirm your e-mail' => 'Registo - Confirme o seu e-mail',
     'Authorization' => 'Autorização',
     'Check your E-mail for further instructions' => 'Verifique o seu e-mail para mais instruções',

--- a/models/forms/LoginForm.php
+++ b/models/forms/LoginForm.php
@@ -32,7 +32,7 @@ class LoginForm extends Model
 	public function attributeLabels()
 	{
 		return [
-			'username'   => UserManagementModule::t('front', 'Login'),
+			'username'   => UserManagementModule::t('front', 'Username'),
 			'password'   => UserManagementModule::t('front', 'Password'),
 			'rememberMe' => UserManagementModule::t('front', 'Remember me'),
 		];


### PR DESCRIPTION
This sugestion comes because in portuguese 'Login' and 'Username' has differents translations and maybe this missunderstanding happens in others languages.
This small change could resolve many  people problems.
Continue with the good work. Thanks
 