### PR TITLE
Fix email maximum length: an entire email address can be up to 254 ch…

### DIFF
--- a/migrations/m170307_100221_update_email_type.php
+++ b/migrations/m170307_100221_update_email_type.php
@@ -1,0 +1,29 @@
+<?php
+
+use yii\db\Migration;
+
+class m170307_100221_update_email_type extends Migration
+{
+    public function up()
+    {
+        $this->alterColumn('user', 'email', 'varchar(254)');
+    }
+
+    public function down()
+    {
+        echo "m170307_100221_update_email_type cannot be reverted.\n";
+
+        return false;
+    }
+
+    /*
+    // Use safeUp/safeDown to run migration code within a transaction
+    public function safeUp()
+    {
+    }
+
+    public function safeDown()
+    {
+    }
+    */
+}

--- a/migrations/mysql.schema.sql
+++ b/migrations/mysql.schema.sql
@@ -280,7 +280,7 @@ CREATE TABLE IF NOT EXISTS `user` (
   `updated_at` int(11) NOT NULL,
   `registration_ip` varchar(15) DEFAULT NULL,
   `bind_to_ip` varchar(255) DEFAULT NULL,
-  `email` varchar(128) DEFAULT NULL,
+  `email` varchar(254) DEFAULT NULL,
   `email_confirmed` smallint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=2 ;

--- a/views/auth/confirmEmail.php
+++ b/views/auth/confirmEmail.php
@@ -34,7 +34,7 @@ $this->params['breadcrumbs'][] = $this->title;
 					'validateOnBlur'=>false,
 				]); ?>
 
-				<?= $form->field($model, 'email')->textInput(['maxlength' => 255, 'autofocus'=>true]) ?>
+				<?= $form->field($model, 'email')->textInput(['maxlength' => 254, 'autofocus'=>true]) ?>
 
 				<div class="form-group">
 					<div class="col-sm-offset-3 col-sm-9">

--- a/views/auth/passwordRecovery.php
+++ b/views/auth/passwordRecovery.php
@@ -30,7 +30,7 @@ $this->params['breadcrumbs'][] = $this->title;
 		'validateOnBlur'=>false,
 	]); ?>
 
-	<?= $form->field($model, 'email')->textInput(['maxlength' => 255, 'autofocus'=>true]) ?>
+	<?= $form->field($model, 'email')->textInput(['maxlength' => 254, 'autofocus'=>true]) ?>
 
 	<?= $form->field($model, 'captcha')->widget(Captcha::className(), [
 		'template' => '<div class="row"><div class="col-sm-2">{image}</div><div class="col-sm-3">{input}</div></div>',

--- a/views/user/_form.php
+++ b/views/user/_form.php
@@ -44,7 +44,7 @@ use webvimark\extensions\BootstrapSwitch\BootstrapSwitch;
 
 	<?php if ( User::hasPermission('editUserEmail') ): ?>
 
-		<?= $form->field($model, 'email')->textInput(['maxlength' => 255]) ?>
+		<?= $form->field($model, 'email')->textInput(['maxlength' => 254]) ?>
 		<?= $form->field($model, 'email_confirmed')->checkbox() ?>
 
 	<?php endif; ?>


### PR DESCRIPTION
…aracters long.

See RFC 3696 erratum 1690:
https://www.rfc-editor.org/errata_search.php?eid=1690

There is a restriction in RFC 2821 on the length of an
address in MAIL and RCPT commands of 254 characters.  Since addresses
that do not fit in those fields are not normally useful, the upper
limit on address lengths should normally be considered to be 254.