### PR TITLE
Fix registration when useEmailAsLogin is true

### DIFF
--- a/models/forms/RegistrationForm.php
+++ b/models/forms/RegistrationForm.php
@@ -89,6 +89,7 @@ class RegistrationForm extends Model
 		}
 
 		$user = new User();
+		$user->username = $this->username;
 		$user->password = $this->password;
 
 		if ( Yii::$app->getModule('user-management')->useEmailAsLogin )
@@ -118,10 +119,6 @@ class RegistrationForm extends Model
 			{
 				$user->username = $this->username;
 			}
-		}
-		else
-		{
-			$user->username = $this->username;
 		}
 
 


### PR DESCRIPTION
I set `enableRegistration = true` and `useEmailAsLogin = true` in config then try to register but had this exception
`Database Exception – yii\db\Exception
SQLSTATE[HY000]: General error: 1364 Field 'username' doesn't have a default value
The SQL being executed was: INSERT INTO `user` (`email`, `status`, `confirmation_token`, `registration_ip`, `auth_key`, `password_hash`, `created_at`, `updated_at`) VALUES ('d@d.com', 0, 'KDsZuiL2sZRFY7tJiCnU7F-AKqpTOrYD_1502566426', '127.0.0.1', '87i6gDXQydakT53XgOWZT0tya7INq0go', '$2y$13$z3qDng4W4TBEwza28IcjV.zm59kHsTMDH4Y3O9D8.aRkQrKTFyUJu', 1502566430, 1502566430)`

so this is me fix to it.