### PR TITLE
Email confirmation with all options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "webvimark/module-user-management",
+	"name": "davidias2004/module-user-management",
 	"description": "User with improved RBAC",
 	"autoload": {
 		"psr-4": {

--- a/controllers/AuthController.php
+++ b/controllers/AuthController.php
@@ -151,19 +151,24 @@ class AuthController extends BaseController
 						if ( Yii::$app->getModule('user-management')->useEmailAsLogin AND Yii::$app->getModule('user-management')->emailConfirmationRequired )
 						{
 							return $this->renderIsAjax('registrationWaitForEmailConfirmation', compact('user'));
-						}
-						else
-						{
-							$roles = (array)$this->module->rolesAfterRegistration;
-
-							foreach ($roles as $role)
-							{
-								User::assignRole($user->id, $role);
-							}
-
-							Yii::$app->user->login($user);
-
-							return $this->redirect(Yii::$app->user->returnUrl);
+						}else{
+						    if (Yii::$app->getModule('user-management')->emailConfirmationRequired )
+						    {
+						        return $this->renderIsAjax('registrationWaitForEmailConfirmation', compact('user'));
+						    }						    
+    						else
+    						{
+    							$roles = (array)$this->module->rolesAfterRegistration;
+    
+    							foreach ($roles as $role)
+    							{
+    								User::assignRole($user->id, $role);
+    							}
+    
+    							Yii::$app->user->login($user);
+    
+    							return $this->redirect(Yii::$app->user->returnUrl);
+    						}
 						}
 
 					}

--- a/controllers/AuthController.php
+++ b/controllers/AuthController.php
@@ -186,7 +186,7 @@ class AuthController extends BaseController
 	 */
 	public function actionConfirmRegistrationEmail($token)
 	{
-		if ( Yii::$app->getModule('user-management')->useEmailAsLogin AND Yii::$app->getModule('user-management')->emailConfirmationRequired )
+		if (Yii::$app->getModule('user-management')->emailConfirmationRequired )
 		{
 			$model = new $this->module->registrationFormClass;
 

--- a/models/forms/RegistrationForm.php
+++ b/models/forms/RegistrationForm.php
@@ -177,7 +177,6 @@ class RegistrationForm extends Model
 
 		if ( $user )
 		{
-			$user->username = $user->email;
 			$user->status = User::STATUS_ACTIVE;
 			$user->email_confirmed = 1;
 			$user->removeConfirmationToken();

--- a/models/forms/RegistrationForm.php
+++ b/models/forms/RegistrationForm.php
@@ -47,6 +47,7 @@ class RegistrationForm extends Model
 		{
 			$rules[] = ['username', 'string', 'max' => 50];
             $rules[] = ['email', 'string', 'max' => 128];
+            $rules[] = ['email', 'email'];
 			$rules[] = ['username', 'match', 'pattern'=>Yii::$app->getModule('user-management')->registrationRegexp];
 			$rules[] = ['username', 'match', 'not'=>true, 'pattern'=>Yii::$app->getModule('user-management')->registrationBlackRegexp];
 			//verification to make email field required ir not

--- a/views/auth/registration.php
+++ b/views/auth/registration.php
@@ -25,6 +25,8 @@ $this->params['breadcrumbs'][] = $this->title;
 	]); ?>
 
 	<?= $form->field($model, 'username')->textInput(['maxlength' => 50, 'autocomplete'=>'off', 'autofocus'=>true]) ?>
+	
+	<?= !Yii::$app->getModule('user-management')->useEmailAsLogin ? $form->field($model, 'email')->textInput(['maxlength' => 128, 'autocomplete'=>'off']) : ''?>
 
 	<?= $form->field($model, 'password')->passwordInput(['maxlength' => 255, 'autocomplete'=>'off']) ?>
 


### PR DESCRIPTION
With this few changes now when can require email confirmation even when we does no use email as login.
Now its possible:
- Use username and require email confirmation
- Use username and do not require email confirmation
- Use email as login and require email confirmation
- Use email as login and do not require email confirmation