### PR TITLE
Fixed issue caused by PHP7.3

### DIFF
--- a/models/rbacDB/AbstractItem.php
+++ b/models/rbacDB/AbstractItem.php
@@ -267,7 +267,7 @@ abstract class AbstractItem extends ActiveRecord
 
 	public static function beforeRemoveChildren($parentName, $childrenNames)
 	{
-		$event = new AbstractItemEvent(compact('parentName', 'childrenNames', 'throwException'));
+		$event = new AbstractItemEvent(compact('parentName', 'childrenNames'));
 		$event->trigger(get_called_class(), self::EVENT_BEFORE_REMOVE_CHILDREN, $event);
 	}
 } 


### PR DESCRIPTION
Fixed issue
throw exception:  compact(): Undefined variable: throwException on PHP 7.3