### PR TITLE
Fixed undefined variable in compact php7.3

### DIFF
--- a/models/rbacDB/AbstractItem.php
+++ b/models/rbacDB/AbstractItem.php
@@ -267,7 +267,7 @@ abstract class AbstractItem extends ActiveRecord
 
 	public static function beforeRemoveChildren($parentName, $childrenNames)
 	{
-		$event = new AbstractItemEvent(compact('parentName', 'childrenNames', 'throwException'));
+		$event = new AbstractItemEvent(compact('parentName', 'childrenNames'));
 		$event->trigger(get_called_class(), self::EVENT_BEFORE_REMOVE_CHILDREN, $event);
 	}
 } 


### PR DESCRIPTION
The compact function throws an error in php7.3 if one of the variables is not defined.
This occured during the saving of roles