### PR TITLE
Creating a controller object with dependency injection support

### DIFF
--- a/components/AuthHelper.php
+++ b/components/AuthHelper.php
@@ -112,7 +112,7 @@ class AuthHelper
 	{
 		touch(static::getPermissionsLastModFile());
 	}
-	
+
 	/**
 	 * Return route without baseUrl and start it with slash
 	 *
@@ -350,7 +350,10 @@ class AuthHelper
 					$className = $namespace . Inflector::id2camel($id) . 'Controller';
 					if ( strpos($className, '-') === false && class_exists($className) && is_subclass_of($className, 'yii\base\Controller') )
 					{
-						$controller = new $className($prefix . $id, $module);
+						$controller = Yii::createObject($className,[
+							+							'id' => $prefix . $id,
+							+							'module' => $module,
+							+							]);
 						self::getActionRoutes($controller, $result);
 						$result[] = '/' . $controller->uniqueId . '/*';
 					}
@@ -358,4 +361,4 @@ class AuthHelper
 			}
 		}
 	}
-} 
+}


### PR DESCRIPTION
Instantiating an object via "new" does not allow injecting a dependency into the controller via the constructor. Instantiation should be via "createobject", this method uses the dependency container when creating the object.